### PR TITLE
Improve mobile chat layout

### DIFF
--- a/assets/src/js/index.js
+++ b/assets/src/js/index.js
@@ -5,3 +5,13 @@ import '../scss/history.scss';
 // Import JS modules
 import './chatbot.js';
 import './history.js'; // Import the history module
+
+document.addEventListener('DOMContentLoaded', () => {
+    if (window.matchMedia('(max-width: 768px)').matches) {
+        const chat = document.getElementById('chatbot-container');
+        const history = document.getElementById('wpai-history');
+        if (chat && history) {
+            chat.parentNode.insertBefore(history, chat.nextSibling);
+        }
+    }
+});

--- a/assets/src/scss/chatbot.scss
+++ b/assets/src/scss/chatbot.scss
@@ -287,3 +287,31 @@
         text-decoration: underline;
     }
 }
+
+@media (max-width: 768px) {
+    #chatbot-container .chat-input-container {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    #chatbot-container #chat-input {
+        margin-bottom: 12px;
+    }
+
+    #chatbot-container #chat-submit {
+        margin-left: 0;
+        width: 100%;
+    }
+
+    #chatbot-container .history-link-mobile {
+        display: block;
+        margin-top: 1rem;
+        text-align: right;
+    }
+}
+
+@media (min-width: 769px) {
+    #chatbot-container .history-link-mobile {
+        display: none;
+    }
+}

--- a/src/Frontend/templates/chatbot-template.php
+++ b/src/Frontend/templates/chatbot-template.php
@@ -17,9 +17,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <div id="chatbot-container" data-nonce="<?php echo esc_attr( $nonce ); ?>" data-enabled="<?php echo $is_enabled ? '1' : '0'; ?>" data-disabled-message="<?php echo esc_attr( $disabled_message ); ?>">
 	<div class="chatgpt-style-container">
-		<div id="chat-header">
-			<div class="chat-title"><?php echo esc_html__( 'T16 Assistant', 'wp-ai-assistant' ); ?></div>
-		</div>
+               <div id="chat-header">
+                       <div class="chat-title"><?php echo esc_html__( 'T16 Assistant', 'wp-ai-assistant' ); ?></div>
+               </div>
+               <div class="history-link-mobile"><a href="#wpai-history"><?php echo esc_html__( 'View history', 'wp-ai-assistant' ); ?></a></div>
 		
 		<div id="chat-messages-container">
 			<div id="chat-output"></div>

--- a/src/Frontend/templates/history-template.php
+++ b/src/Frontend/templates/history-template.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div class="wpai-history-container">
+<div id="wpai-history" class="wpai-history-container">
 	<h2><?php echo esc_html( $title ); ?></h2>
 
 	<?php if ( empty( $threads ) ) : ?>


### PR DESCRIPTION
## Summary
- add responsive history link below chat header
- show chat history after the chat input on mobile screens
- move send button below input on mobile

## Testing
- `npm run build`
- `composer lint` *(fails: code style errors)*

------
https://chatgpt.com/codex/tasks/task_e_6873e7a53bbc83219b42bf46d7ff3f0a