### PR TITLE
Log visitor details for conversations

### DIFF
--- a/src/Admin/ConversationMetaBox.php
+++ b/src/Admin/ConversationMetaBox.php
@@ -33,15 +33,29 @@ class ConversationMetaBox {
 	 * Render the meta box content.
 	 *
 	 * @param \WP_Post $post Current post object.
-	 */
-	public static function render_meta_box( \WP_Post $post ): void {
-		// Get conversation messages
-		$messages = get_post_meta( $post->ID, 'messages', true );
+        */
+       public static function render_meta_box( \WP_Post $post ): void {
+               $ip        = get_post_meta( $post->ID, 'user_ip', true );
+               $user_agent = get_post_meta( $post->ID, 'user_agent', true );
 
-		if ( empty( $messages ) ) {
-			echo '<p>' . esc_html__( 'There are no messages in this conversation.', 'wp-ai-assistant' ) . '</p>';
-			return;
-		}
+               if ( $ip || $user_agent ) {
+                       echo '<p class="ai-visitor-info">';
+                       if ( $ip ) {
+                               echo '<strong>' . esc_html__( 'IP Address', 'wp-ai-assistant' ) . ':</strong> ' . esc_html( $ip ) . '<br />';
+                       }
+                       if ( $user_agent ) {
+                               echo '<strong>' . esc_html__( 'User Agent', 'wp-ai-assistant' ) . ':</strong> ' . esc_html( $user_agent ) . '<br />';
+                       }
+                       echo '</p>';
+               }
+
+               // Get conversation messages
+               $messages = get_post_meta( $post->ID, 'messages', true );
+
+               if ( empty( $messages ) ) {
+                       echo '<p>' . esc_html__( 'There are no messages in this conversation.', 'wp-ai-assistant' ) . '</p>';
+                       return;
+               }
 
 		echo '<div class="ai-conversation-history">';
 
@@ -64,10 +78,10 @@ class ConversationMetaBox {
 			echo '</div>';
 		}
 
-		echo '</div>';
+                echo '</div>';
 
-		// Add some basic styling
-		echo '<style>
+                // Add some basic styling
+                echo '<style>
             .ai-conversation-history {
                 max-height: 500px;
                 overflow-y: auto;
@@ -102,6 +116,9 @@ class ConversationMetaBox {
             .message-content p:last-child {
                 margin-bottom: 0;
             }
+            .ai-visitor-info {
+                margin-bottom: 10px;
+            }
         </style>';
-	}
+        }
 }

--- a/src/Domain/Thread/ChatThreadPostType.php
+++ b/src/Domain/Thread/ChatThreadPostType.php
@@ -67,33 +67,55 @@ class ChatThreadPostType {
 			)
 		);
 
-		register_meta(
-			'post',
-			'messages',
-			array(
-				'object_subtype' => 'ai_chat_thread',
-				'type'           => 'array',
-				'single'         => true,
-				'show_in_rest'   => array(
-					'schema' => array(
-						'type'  => 'array',
-						'items' => array(
-							'type'       => 'object',
-							'properties' => array(
-								'role'      => array(
-									'type' => 'string',
-								),
-								'content'   => array(
-									'type' => 'string',
-								),
-								'timestamp' => array(
-									'type' => 'integer',
-								),
-							),
-						),
-					),
-				),
-			)
-		);
-	}
+                register_meta(
+                        'post',
+                        'messages',
+                        array(
+                                'object_subtype' => 'ai_chat_thread',
+                                'type'           => 'array',
+                                'single'         => true,
+                                'show_in_rest'   => array(
+                                        'schema' => array(
+                                                'type'  => 'array',
+                                                'items' => array(
+                                                        'type'       => 'object',
+                                                        'properties' => array(
+                                                                'role'      => array(
+                                                                        'type' => 'string',
+                                                                ),
+                                                                'content'   => array(
+                                                                        'type' => 'string',
+                                                                ),
+                                                                'timestamp' => array(
+                                                                        'type' => 'integer',
+                                                                ),
+                                                        ),
+                                                ),
+                                        ),
+                                ),
+                        )
+                );
+
+               register_meta(
+                       'post',
+                       'user_ip',
+                       array(
+                               'object_subtype' => 'ai_chat_thread',
+                               'type'           => 'string',
+                               'single'         => true,
+                               'show_in_rest'   => true,
+                       )
+               );
+
+               register_meta(
+                       'post',
+                       'user_agent',
+                       array(
+                               'object_subtype' => 'ai_chat_thread',
+                               'type'           => 'string',
+                               'single'         => true,
+                               'show_in_rest'   => true,
+                       )
+               );
+        }
 }

--- a/src/Infrastructure/Persistence/WPThreadRepository.php
+++ b/src/Infrastructure/Persistence/WPThreadRepository.php
@@ -42,10 +42,14 @@ class WPThreadRepository implements ThreadRepository {
 			return 0;
 		}
 
-		// Save thread metadata.
-		update_post_meta( $post_id, 'thread_external_id', $thread_id );
-		update_post_meta( $post_id, 'session_id', $session_id );
-		update_post_meta( $post_id, 'messages', array() );
+                // Save thread metadata.
+                update_post_meta( $post_id, 'thread_external_id', $thread_id );
+                update_post_meta( $post_id, 'session_id', $session_id );
+                update_post_meta( $post_id, 'messages', array() );
+               $user_ip    = $this->getClientIp();
+               $user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
+               update_post_meta( $post_id, 'user_ip', $user_ip );
+               update_post_meta( $post_id, 'user_agent', $user_agent );
 
 		Logger::log( 'Created new thread post #' . $post_id . ' for thread ' . $thread_id );
 
@@ -128,17 +132,19 @@ class WPThreadRepository implements ThreadRepository {
 			return null;
 		}
 
-		$post    = $posts[0];
-		$post_id = $post->ID;
+                $post    = $posts[0];
+                $post_id = $post->ID;
 
-		return array(
-			'post_id'    => $post_id,
-			'title'      => $post->post_title,
-			'thread_id'  => $thread_id,
-			'session_id' => get_post_meta( $post_id, 'session_id', true ),
-			'messages'   => get_post_meta( $post_id, 'messages', true ) ?: array(),
-		);
-	}
+                return array(
+                        'post_id'    => $post_id,
+                        'title'      => $post->post_title,
+                        'thread_id'  => $thread_id,
+                        'session_id' => get_post_meta( $post_id, 'session_id', true ),
+                       'messages'   => get_post_meta( $post_id, 'messages', true ) ?: array(),
+                       'user_ip'    => get_post_meta( $post_id, 'user_ip', true ),
+                       'user_agent' => get_post_meta( $post_id, 'user_agent', true ),
+                );
+        }
 
 	/**
 	 * Get threads for a specific user or session ID.
@@ -175,17 +181,19 @@ class WPThreadRepository implements ThreadRepository {
 
 		foreach ( $posts as $post ) {
 			$summary   = has_excerpt( $post ) ? get_the_excerpt( $post ) : $this->getFirstUserMessage( $post->ID );
-			$threads[] = array(
-				'post_id'      => $post->ID,
-				'title'        => $post->post_title,
-				'summary'      => $summary,
-				'date'         => get_the_date( 'Y-m-d H:i:s', $post->ID ),
-				'thread_id'    => get_post_meta( $post->ID, 'thread_external_id', true ),
-				'session_id'   => get_post_meta( $post->ID, 'session_id', true ),
-				'messages'     => get_post_meta( $post->ID, 'messages', true ) ?: array(),
-				'last_message' => $this->getLastMessages( $post->ID ),
-			);
-		}
+                       $threads[] = array(
+                               'post_id'      => $post->ID,
+                               'title'        => $post->post_title,
+                               'summary'      => $summary,
+                               'date'         => get_the_date( 'Y-m-d H:i:s', $post->ID ),
+                               'thread_id'    => get_post_meta( $post->ID, 'thread_external_id', true ),
+                               'session_id'   => get_post_meta( $post->ID, 'session_id', true ),
+                               'messages'     => get_post_meta( $post->ID, 'messages', true ) ?: array(),
+                               'last_message' => $this->getLastMessages( $post->ID ),
+                               'user_ip'      => get_post_meta( $post->ID, 'user_ip', true ),
+                               'user_agent'   => get_post_meta( $post->ID, 'user_agent', true ),
+                       );
+               }
 
 		return $threads;
 	}
@@ -244,14 +252,34 @@ class WPThreadRepository implements ThreadRepository {
 	 * @param array $messages The array of message data.
 	 * @return string Formatted content.
 	 */
-	private function generatePostContent( array $messages ): string {
-		$content = '';
+        private function generatePostContent( array $messages ): string {
+                $content = '';
 
 		foreach ( $messages as $message ) {
 			$role     = ucfirst( $message['role'] );
 			$content .= "{$role}: {$message['content']}\n\n";
 		}
 
-		return $content;
-	}
+                return $content;
+        }
+
+       /**
+        * Retrieve the client's IP address.
+        *
+        * @return string IP address if available.
+        */
+       private function getClientIp(): string {
+               $ip = '';
+
+               if ( ! empty( $_SERVER['HTTP_CLIENT_IP'] ) ) {
+                       $ip = $_SERVER['HTTP_CLIENT_IP'];
+               } elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+                       $ip_list = explode( ',', $_SERVER['HTTP_X_FORWARDED_FOR'] );
+                       $ip      = trim( $ip_list[0] );
+               } elseif ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
+                       $ip = $_SERVER['REMOTE_ADDR'];
+               }
+
+               return sanitize_text_field( wp_unslash( $ip ) );
+       }
 }


### PR DESCRIPTION
## Summary
- record visitor IP and user agent when saving new chat threads
- register and expose new metadata fields
- display visitor details on conversation admin pages

## Testing
- `composer lint` (fails: Filenames should be all lowercase with hyphens as word separators. Expected logger.php, but found Logger.php.)
- `vendor/bin/phpstan analyse --memory-limit=512M` (fails: Child process error: PHPStan process crashed because it reached configured PHP memory limit: 512M)

------
https://chatgpt.com/codex/tasks/task_e_68c600db44488321a7296d85abd691e9