### PR TITLE
feat: improve conversation history filtering and bulk actions

### DIFF
--- a/assets/src/js/history.js
+++ b/assets/src/js/history.js
@@ -1,93 +1,444 @@
 /**
  * History functionality for WP AI Assistant plugin
  */
-document.addEventListener("DOMContentLoaded", function() {
+document.addEventListener('DOMContentLoaded', () => {
+    const historyData = window.wpAIAssistantHistory || {};
+
+    /**
+     * Update empty state visibility based on current threads.
+     */
+    function updateEmptyState() {
+        const threadsContainer = document.querySelector('.wpai-history-threads');
+        const emptyState = document.querySelector('.wpai-history-empty');
+
+        if (!threadsContainer || !emptyState) {
+            return;
+        }
+
+        const allThreads = threadsContainer.querySelectorAll('.wpai-thread');
+        const visibleThreads = threadsContainer.querySelectorAll('.wpai-thread:not(.wpai-thread-hidden)');
+
+        if (allThreads.length === 0) {
+            emptyState.textContent = historyData?.i18n?.noConversations || '';
+            emptyState.style.display = 'block';
+            return;
+        }
+
+        if (visibleThreads.length === 0) {
+            emptyState.textContent = historyData?.i18n?.noFilterResults || '';
+            emptyState.style.display = 'block';
+        } else {
+            emptyState.style.display = 'none';
+        }
+    }
+
+    /**
+     * Set thread button label when showing/hiding messages.
+     *
+     * @param {HTMLElement|null} button
+     * @param {boolean} isVisible
+     */
+    function setThreadButtonLabel(button, isVisible) {
+        if (!button || !historyData.i18n) {
+            return;
+        }
+
+        button.textContent = isVisible
+            ? historyData.i18n.hideConversation
+            : historyData.i18n.viewFullConversation;
+    }
+
+    /**
+     * Show thread messages.
+     *
+     * @param {HTMLElement} thread
+     * @param {HTMLElement|null} button
+     */
+    function showThreadMessages(thread, button = null) {
+        if (!thread) {
+            return;
+        }
+        const messagesContainer = thread.querySelector('.wpai-thread-messages');
+        if (!messagesContainer) {
+            return;
+        }
+
+        messagesContainer.style.display = 'block';
+        setThreadButtonLabel(button, true);
+    }
+
+    /**
+     * Hide thread messages.
+     *
+     * @param {HTMLElement} thread
+     * @param {HTMLElement|null} button
+     */
+    function hideThreadMessages(thread, button = null) {
+        if (!thread) {
+            return;
+        }
+        const messagesContainer = thread.querySelector('.wpai-thread-messages');
+        if (!messagesContainer) {
+            return;
+        }
+
+        messagesContainer.style.display = 'none';
+        setThreadButtonLabel(button, false);
+    }
+
+    /**
+     * Toggle thread messages visibility.
+     *
+     * @param {HTMLElement} thread
+     * @param {HTMLElement} button
+     */
+    function toggleThreadMessages(thread, button) {
+        if (!thread) {
+            return;
+        }
+        const messagesContainer = thread.querySelector('.wpai-thread-messages');
+        if (!messagesContainer) {
+            return;
+        }
+
+        const shouldShow = messagesContainer.style.display !== 'block';
+        if (shouldShow) {
+            showThreadMessages(thread, button);
+        } else {
+            hideThreadMessages(thread, button);
+        }
+    }
+
+    /**
+     * Continue chat helper shared by buttons and bulk actions.
+     *
+     * @param {string} threadId
+     * @param {string|null} redirectUrl
+     */
+    function continueChat(threadId, redirectUrl = null) {
+        if (!threadId) {
+            return;
+        }
+
+        try {
+            sessionStorage.setItem('wpai_current_thread', threadId);
+        } catch (e) {
+            if (historyData?.i18n?.sessionStorageNotAvailable) {
+                console.log(historyData.i18n.sessionStorageNotAvailable);
+            }
+        }
+
+        const chatbotContainer = document.getElementById('chatbot-container');
+
+        if (chatbotContainer) {
+            chatbotContainer.setAttribute('data-thread-id', threadId);
+
+            const outputEl = chatbotContainer.querySelector('#chat-output');
+            if (outputEl) {
+                const botMessage = document.createElement('div');
+                botMessage.className = 'chat-message assistant';
+                botMessage.innerHTML = historyData?.i18n?.continueConversationMessage || '';
+                outputEl.appendChild(botMessage);
+                outputEl.style.display = 'block';
+                outputEl.scrollTop = outputEl.scrollHeight;
+            }
+
+            const inputEl = chatbotContainer.querySelector('#chat-input');
+            if (inputEl) {
+                inputEl.setAttribute(
+                    'placeholder',
+                    historyData?.i18n?.continueConversationPlaceholder || ''
+                );
+                inputEl.focus();
+            }
+
+            chatbotContainer.scrollIntoView({
+                behavior: 'smooth',
+                block: 'start'
+            });
+
+            return;
+        }
+
+        if (redirectUrl) {
+            window.location.href = redirectUrl;
+            return;
+        }
+
+        if (historyData?.i18n?.chatbotNotAvailableAlert) {
+            alert(historyData.i18n.chatbotNotAvailableAlert);
+        }
+    }
+
     /**
      * Initialize view thread functionality
      */
     function initViewThreadButtons() {
         const viewButtons = document.querySelectorAll('.wpai-view-thread');
         if (viewButtons.length === 0) return;
-        
+
         viewButtons.forEach(button => {
             button.addEventListener('click', function() {
                 const threadContainer = this.closest('.wpai-thread');
-                const messagesContainer = threadContainer.querySelector('.wpai-thread-messages');
-                
-                if (messagesContainer.style.display === 'block') {
-                    messagesContainer.style.display = 'none';
-                    this.textContent = wpAIAssistantHistory.i18n.viewFullConversation;
-                } else {
-                    messagesContainer.style.display = 'block';
-                    this.textContent = wpAIAssistantHistory.i18n.hideConversation;
-                }
+                toggleThreadMessages(threadContainer, this);
             });
         });
     }
-    
+
     /**
      * Initialize continue chat functionality
      */
     function initContinueChatButtons() {
         const continueButtons = document.querySelectorAll('.wpai-continue-chat');
         if (continueButtons.length === 0) return;
-        
+
         continueButtons.forEach(button => {
             button.addEventListener('click', function() {
                 const threadId = this.getAttribute('data-thread-id');
+                const redirectUrl = this.getAttribute('data-redirect-url');
                 if (!threadId) return;
-                
-                // Save thread ID to session storage
-                try {
-                    sessionStorage.setItem('wpai_current_thread', threadId);
-                } catch (e) {
-                    console.log(wpAIAssistantHistory.i18n.sessionStorageNotAvailable);
-                }
-                
-                // Find chatbot container on page
-                const chatbotContainer = document.getElementById('chatbot-container');
-                
-                if (chatbotContainer) {
-                    // Set thread ID on container
-                    chatbotContainer.setAttribute('data-thread-id', threadId);
-                    
-                    // Add message to chat output
-                    const outputEl = chatbotContainer.querySelector('#chat-output');
-                    if (outputEl) {
-                        const botMessage = document.createElement('div');
-                        botMessage.className = 'chat-message assistant';
-                        botMessage.innerHTML = wpAIAssistantHistory.i18n.continueConversationMessage;
-                        outputEl.appendChild(botMessage);
-                        outputEl.style.display = 'block';
-                        outputEl.scrollTop = outputEl.scrollHeight;
-                    }
-                    
-                    // Update input placeholder
-                    const inputEl = chatbotContainer.querySelector('#chat-input');
-                    if (inputEl) {
-                        inputEl.setAttribute('placeholder', wpAIAssistantHistory.i18n.continueConversationPlaceholder);
-                        inputEl.focus();
-                    }
-                    
-                    // Scroll to chatbot
-                    chatbotContainer.scrollIntoView({
-                        behavior: 'smooth',
-                        block: 'start'
-                    });
-                } else {
-                    // If chatbot not on page, check for redirect URL
-                    const redirectUrl = this.getAttribute('data-redirect-url');
-                    if (redirectUrl) {
-                        window.location.href = redirectUrl;
-                    } else {
-                        alert(wpAIAssistantHistory.i18n.chatbotNotAvailableAlert);
-                    }
-                }
+
+                continueChat(threadId, redirectUrl || null);
             });
         });
     }
-    
-    // Initialize functionality
+
+    /**
+     * Initialize filter controls so nothing is selected by default.
+     */
+    function initFilters() {
+        const filterInputs = document.querySelectorAll('.wpai-filter-input');
+        if (filterInputs.length === 0) {
+            return;
+        }
+
+        filterInputs.forEach(input => {
+            input.checked = false;
+        });
+
+        function applyFilters() {
+            const threads = document.querySelectorAll('.wpai-thread');
+            const activeFilters = Array.from(filterInputs)
+                .filter(input => input.checked)
+                .map(input => input.dataset.filter);
+
+            threads.forEach(thread => {
+                const status = thread.dataset.status;
+                const shouldHide = activeFilters.length > 0 && !activeFilters.includes(status);
+                thread.classList.toggle('wpai-thread-hidden', shouldHide);
+            });
+
+            updateEmptyState();
+            document.dispatchEvent(new CustomEvent('wpai:refresh-selection'));
+        }
+
+        filterInputs.forEach(input => {
+            input.addEventListener('change', applyFilters);
+        });
+
+        applyFilters();
+    }
+
+    /**
+     * Initialize bulk selection and actions.
+     */
+    function initSelection() {
+        const actionBar = document.querySelector('.wpai-bulk-actions');
+        const actionSelect = document.getElementById('wpai-bulk-action-select');
+        const applyButton = document.getElementById('wpai-bulk-action-apply');
+        const selectionCount = document.querySelector('.wpai-selection-count');
+        const selectAll = document.getElementById('wpai-select-all');
+
+        if (!actionBar || !actionSelect || !applyButton) {
+            return;
+        }
+
+        function getAllCheckboxes() {
+            return Array.from(document.querySelectorAll('.wpai-thread-checkbox'));
+        }
+
+        function getVisibleCheckboxes() {
+            return getAllCheckboxes().filter(checkbox => {
+                const thread = checkbox.closest('.wpai-thread');
+                return thread && !thread.classList.contains('wpai-thread-hidden');
+            });
+        }
+
+        function getSelectedCheckboxes() {
+            return getAllCheckboxes().filter(checkbox => checkbox.checked);
+        }
+
+        function toggleActionBar(visible) {
+            if (visible) {
+                actionBar.classList.add('visible');
+                actionBar.setAttribute('aria-hidden', 'false');
+            } else {
+                actionBar.classList.remove('visible');
+                actionBar.setAttribute('aria-hidden', 'true');
+                actionSelect.value = '';
+            }
+        }
+
+        function updateSelectionCount(count) {
+            if (!selectionCount) {
+                return;
+            }
+
+            const template = count === 1
+                ? historyData?.i18n?.selectionSingle
+                : historyData?.i18n?.selectionPlural;
+
+            if (template) {
+                selectionCount.textContent = template.replace('%d', count);
+            } else {
+                selectionCount.textContent = `${count}`;
+            }
+        }
+
+        function updateSelectionState() {
+            const selected = getSelectedCheckboxes();
+            const visibleCheckboxes = getVisibleCheckboxes();
+
+            if (selectAll) {
+                const allVisibleSelected = selected.length > 0 && selected.length === visibleCheckboxes.length;
+                selectAll.checked = allVisibleSelected && visibleCheckboxes.length > 0;
+                selectAll.indeterminate = selected.length > 0 && selected.length < visibleCheckboxes.length;
+            }
+
+            updateSelectionCount(selected.length);
+            toggleActionBar(selected.length > 0);
+        }
+
+        function handleBulkView(selectedCheckboxes) {
+            const firstCheckbox = selectedCheckboxes[0];
+            if (!firstCheckbox) {
+                return;
+            }
+
+            const thread = firstCheckbox.closest('.wpai-thread');
+            if (!thread) {
+                return;
+            }
+
+            const button = thread.querySelector('.wpai-view-thread');
+            showThreadMessages(thread, button || null);
+            thread.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+
+        function handleBulkDelete(selectedCheckboxes) {
+            if (!historyData?.i18n?.deleteConfirmation) {
+                return;
+            }
+
+            if (!window.confirm(historyData.i18n.deleteConfirmation)) {
+                return;
+            }
+
+            const ids = selectedCheckboxes.map(checkbox => checkbox.value).filter(Boolean);
+            if (ids.length === 0) {
+                return;
+            }
+
+            const params = new URLSearchParams();
+            params.append('action', 'wp_ai_assistant_delete_threads');
+            params.append('thread_ids', JSON.stringify(ids));
+            params.append('_ajax_nonce', historyData.nonce);
+
+            fetch(historyData.ajaxurl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+                },
+                credentials: 'same-origin',
+                body: params.toString()
+            })
+                .then(response => response.json())
+                .then(data => {
+                    if (!data || data.success !== true) {
+                        const message = data?.data?.message || historyData?.i18n?.deleteError;
+                        throw new Error(message);
+                    }
+
+                    const deleted = Array.isArray(data.data?.deleted) ? data.data.deleted : [];
+                    const failed = Array.isArray(data.data?.failed) ? data.data.failed : [];
+
+                    deleted.forEach(postId => {
+                        const thread = document.querySelector(`.wpai-thread[data-post-id="${postId}"]`);
+                        if (thread) {
+                            thread.remove();
+                        }
+                    });
+
+                    if (failed.length > 0 && historyData?.i18n?.deletePartial) {
+                        alert(historyData.i18n.deletePartial);
+                    }
+
+                    document.dispatchEvent(new CustomEvent('wpai:refresh-selection'));
+                    updateEmptyState();
+                })
+                .catch(error => {
+                    const message = error?.message || historyData?.i18n?.deleteError || '';
+                    if (message) {
+                        alert(message);
+                    }
+                });
+        }
+
+        function handleBulkAction() {
+            const selectedCheckboxes = getSelectedCheckboxes();
+            if (selectedCheckboxes.length === 0) {
+                if (historyData?.i18n?.noSelection) {
+                    alert(historyData.i18n.noSelection);
+                }
+                return;
+            }
+
+            const action = actionSelect.value;
+            if (!action) {
+                if (historyData?.i18n?.selectAction) {
+                    alert(historyData.i18n.selectAction);
+                }
+                return;
+            }
+
+            if ('view' === action) {
+                handleBulkView(selectedCheckboxes);
+            } else if ('delete' === action) {
+                handleBulkDelete(selectedCheckboxes);
+            }
+        }
+
+        function handleSelectAllChange() {
+            const isChecked = selectAll.checked;
+            const visibleCheckboxes = getVisibleCheckboxes();
+
+            visibleCheckboxes.forEach(checkbox => {
+                checkbox.checked = isChecked;
+            });
+
+            updateSelectionState();
+        }
+
+        getAllCheckboxes().forEach(checkbox => {
+            checkbox.addEventListener('change', updateSelectionState);
+        });
+
+        if (selectAll) {
+            selectAll.checked = false;
+            selectAll.indeterminate = false;
+            selectAll.addEventListener('change', handleSelectAllChange);
+        }
+
+        applyButton.addEventListener('click', handleBulkAction);
+
+        document.addEventListener('wpai:refresh-selection', updateSelectionState);
+
+        updateSelectionState();
+    }
+
     initViewThreadButtons();
     initContinueChatButtons();
+    initFilters();
+    initSelection();
+    updateEmptyState();
 });

--- a/assets/src/scss/history.scss
+++ b/assets/src/scss/history.scss
@@ -29,6 +29,129 @@
     font-size: 0.95rem;
 }
 
+.wpai-history-controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.wpai-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.wpai-filter {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 9999px;
+    background-color: #f7f7f8;
+    border: 1px solid #e5e5e5;
+    font-size: 0.85rem;
+    color: #343541;
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+
+    input {
+        margin: 0;
+    }
+
+    &:hover {
+        background-color: #efeff1;
+        border-color: #d7d7d7;
+    }
+}
+
+.wpai-select-all {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9rem;
+    color: #343541;
+
+    input {
+        margin: 0;
+    }
+}
+
+.wpai-bulk-actions {
+    display: none;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    margin-bottom: 16px;
+    background-color: #ffffff;
+    border: 1px solid #e5e5e5;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    position: sticky;
+    top: 16px;
+    z-index: 30;
+
+    &.visible {
+        display: flex;
+    }
+}
+
+.wpai-selection-count {
+    font-weight: 500;
+    color: #343541;
+}
+
+.wpai-bulk-action-select {
+    min-width: 200px;
+    padding: 8px 12px;
+    border-radius: 6px;
+    border: 1px solid #d1d1d1;
+    background-color: #ffffff;
+    font-size: 0.9rem;
+    color: #343541;
+}
+
+.wpai-bulk-action-apply {
+    padding: 8px 16px;
+    border-radius: 6px;
+    border: none;
+    background-color: #374151;
+    color: #ffffff;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+        background-color: #1f2937;
+    }
+}
+
+.wpai-history-empty {
+    display: none;
+    padding: 16px;
+    background-color: #f7f7f8;
+    border: 1px dashed #d1d1d1;
+    border-radius: 8px;
+    color: #8e8ea0;
+    text-align: center;
+    font-size: 0.9rem;
+    margin-bottom: 12px;
+}
+
+.screen-reader-text {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+}
+
 .wpai-history-threads {
     margin-top: 24px;
     display: flex;
@@ -40,13 +163,13 @@
     margin-bottom: 0;
     padding: 20px;
     border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0,0,0,.1);
-    background-color: #fff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    background-color: #ffffff;
     border: 1px solid #e5e5e5;
     transition: all 0.2s ease;
 
     &:hover {
-        box-shadow: 0 2px 10px rgba(0,0,0,.1);
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
         border-color: #d1d1d1;
     }
 }
@@ -58,6 +181,19 @@
     margin-bottom: 16px;
     padding-bottom: 12px;
     border-bottom: 1px solid #e5e5e5;
+}
+
+.wpai-thread-select {
+    margin-right: 12px;
+    padding-top: 2px;
+}
+
+.wpai-thread-header-content {
+    flex: 1;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
 
     h3 {
         margin: 0;
@@ -65,6 +201,7 @@
         font-weight: 500;
         color: #343541;
         line-height: 1.4;
+        flex: 1;
     }
 }
 
@@ -83,14 +220,14 @@
     line-height: 1.5;
 }
 
-.wpai-preview-user, 
+.wpai-preview-user,
 .wpai-preview-assistant {
     margin-bottom: 10px;
     position: relative;
     padding-left: 24px;
 }
 
-.wpai-preview-user .preview-label, 
+.wpai-preview-user .preview-label,
 .wpai-preview-assistant .preview-label {
     font-weight: 600;
     margin-right: 5px;
@@ -121,7 +258,7 @@
         align-items: center;
         justify-content: center;
         gap: 8px;
-        
+
         svg {
             stroke-width: 2;
         }
@@ -136,7 +273,7 @@
     &:hover {
         background-color: #efeff1;
     }
-    
+
     &:active {
         background-color: #e5e5e5;
     }
@@ -144,13 +281,13 @@
 
 .wpai-continue-chat {
     background-color: #374151;
-    color: white;
+    color: #ffffff;
     border: 1px solid #374151;
 
     &:hover {
         background-color: #1f2937;
     }
-    
+
     &:active {
         background-color: #1f2937;
     }
@@ -163,6 +300,10 @@
     padding-top: 20px;
     max-height: 500px;
     overflow-y: auto;
+}
+
+.wpai-thread.wpai-thread-hidden {
+    display: none;
 }
 
 .wpai-message {
@@ -179,12 +320,12 @@
 
     &.wpai-message-user {
         background-color: #343541;
-        color: white;
-        
+        color: #ffffff;
+
         .message-role {
-            color: white;
+            color: #ffffff;
         }
-        
+
         .wpai-message-header {
             color: rgba(255, 255, 255, 0.7);
         }
@@ -193,11 +334,11 @@
     &.wpai-message-assistant {
         background-color: #f7f7f8;
         color: #343541;
-        
+
         .message-role {
             color: #10a37f;
         }
-        
+
         pre {
             background-color: rgba(0, 0, 0, 0.05);
             border-radius: 6px;
@@ -205,7 +346,7 @@
             overflow-x: auto;
             margin: 12px 0;
         }
-        
+
         code {
             background-color: rgba(0, 0, 0, 0.05);
             font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
@@ -224,11 +365,11 @@
     font-size: 0.85rem;
     color: #8e8ea0;
     font-weight: 500;
-    
+
     strong {
         color: inherit;
     }
-    
+
     .message-role {
         font-weight: 600;
         font-size: 0.9rem;
@@ -238,46 +379,48 @@
 .wpai-message-content {
     font-size: 0.95rem;
     line-height: 1.6;
-    
+
     p {
         margin: 0 0 16px;
     }
-    
+
     p:last-child {
         margin-bottom: 0;
     }
-    
-    pre, code {
-        background-color: rgba(0,0,0,0.05);
+
+    pre,
+    code {
+        background-color: rgba(0, 0, 0, 0.05);
         padding: 2px 4px;
         border-radius: 4px;
         font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
         font-size: 0.9em;
     }
-    
+
     pre {
         padding: 12px;
         margin: 16px 0;
         overflow-x: auto;
     }
-    
-    ul, ol {
+
+    ul,
+    ol {
         margin: 16px 0;
         padding-left: 24px;
     }
-    
+
     li {
         margin-bottom: 6px;
     }
-    
+
     li:last-child {
         margin-bottom: 0;
     }
-    
+
     a {
         color: #10a37f;
         text-decoration: underline;
-        
+
         &:hover {
             text-decoration: none;
         }
@@ -289,16 +432,40 @@
     .wpai-history-container {
         padding: 16px 0;
     }
-    
+
+    .wpai-history-controls {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .wpai-bulk-actions {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .wpai-bulk-action-select {
+        width: 100%;
+    }
+
+    .wpai-bulk-action-apply {
+        width: 100%;
+        text-align: center;
+    }
+
     .wpai-thread-header {
         flex-direction: column;
         align-items: flex-start;
     }
-    
+
+    .wpai-thread-header-content {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
     .wpai-thread-date {
         margin: 4px 0 0 0;
     }
-    
+
     .wpai-thread-actions {
         width: 100%;
         flex-direction: column;
@@ -308,7 +475,7 @@
             width: 100%;
         }
     }
-    
+
     .wpai-message {
         padding: 12px;
     }

--- a/src/Frontend/ChatShortcode.php
+++ b/src/Frontend/ChatShortcode.php
@@ -149,9 +149,18 @@ class ChatShortcode
             'continueConversationPlaceholder' => __('Continue conversation...', 'wp-ai-assistant'),
             'chatbotNotAvailableAlert'        => __('The chatbot is not available on this page. Please go to a page with the chatbot to continue the conversation.', 'wp-ai-assistant'),
             'sessionStorageNotAvailable'      => __('Session storage not available', 'wp-ai-assistant'),
+            'noSelection'                     => __('Please select at least one conversation to apply an action.', 'wp-ai-assistant'),
+            'selectAction'                    => __('Please choose an action to apply.', 'wp-ai-assistant'),
+            'deleteConfirmation'              => __('Are you sure you want to permanently delete the selected conversations?', 'wp-ai-assistant'),
+            'deleteError'                     => __('We could not delete the selected conversations. Please try again.', 'wp-ai-assistant'),
+            'deletePartial'                   => __('Some conversations could not be deleted because of missing permissions.', 'wp-ai-assistant'),
+            'selectionSingle'                 => __('%d conversation selected', 'wp-ai-assistant'),
+            'selectionPlural'                 => __('%d conversations selected', 'wp-ai-assistant'),
+            'noFilterResults'                 => __('No conversations match the selected filters.', 'wp-ai-assistant'),
+            'noConversations'                 => __('There are no conversations to display yet.', 'wp-ai-assistant'),
             ),
             )
-        );        
+        );
 
         wp_add_inline_style('wp-ai-assistant-style', self::get_styles());
     }

--- a/src/Frontend/templates/history-template.php
+++ b/src/Frontend/templates/history-template.php
@@ -21,66 +21,120 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<?php if ( empty( $threads ) ) : ?>
 		<p class="wpai-no-history"><?php esc_html_e( 'You have no saved conversations yet.', 'wp-ai-assistant' ); ?></p>
-	<?php else : ?>
-		<div class="wpai-history-threads">
-			<?php foreach ( $threads as $thread ) : ?>
-				<div class="wpai-thread" data-thread-id="<?php echo esc_attr( $thread['thread_id'] ); ?>">
-										<div class="wpai-thread-header">
-												<h3><?php echo esc_html( $thread['summary'] ); ?></h3>
-												<span class="wpai-thread-date"><?php echo esc_html( $thread['date'] ); ?></span>
-										</div>
+<?php else : ?>
+                <div class="wpai-history-controls">
+                        <div class="wpai-filters" role="group" aria-label="<?php esc_attr_e( 'Filter conversations', 'wp-ai-assistant' ); ?>">
+                                <label class="wpai-filter">
+                                        <input type="checkbox" class="wpai-filter-input" data-filter="pending" />
+                                        <span><?php esc_html_e( 'Awaiting reply', 'wp-ai-assistant' ); ?></span>
+                                </label>
+                                <label class="wpai-filter">
+                                        <input type="checkbox" class="wpai-filter-input" data-filter="answered" />
+                                        <span><?php esc_html_e( 'Answered', 'wp-ai-assistant' ); ?></span>
+                                </label>
+                        </div>
+                        <label class="wpai-select-all">
+                                <input type="checkbox" id="wpai-select-all" aria-label="<?php esc_attr_e( 'Select all visible conversations', 'wp-ai-assistant' ); ?>" />
+                                <span><?php esc_html_e( 'Select all visible', 'wp-ai-assistant' ); ?></span>
+                        </label>
+                </div>
 
-					<div class="wpai-thread-preview">
-						<?php if ( ! empty( $thread['last_message']['user_message'] ) ) : ?>
-							<div class="wpai-preview-user">
-								<span class="preview-label"><?php esc_html_e( 'You:', 'wp-ai-assistant' ); ?></span> <?php echo esc_html( wp_trim_words( $thread['last_message']['user_message'], 15 ) ); ?>
-							</div>
-						<?php endif; ?>
+                <div class="wpai-bulk-actions" aria-hidden="true" role="region" aria-live="polite">
+                        <span class="wpai-selection-count"><?php echo esc_html( sprintf( __( '%d conversations selected', 'wp-ai-assistant' ), 0 ) ); ?></span>
+                        <label class="screen-reader-text" for="wpai-bulk-action-select"><?php esc_html_e( 'Choose an action to perform on the selected conversations', 'wp-ai-assistant' ); ?></label>
+                        <select id="wpai-bulk-action-select" class="wpai-bulk-action-select">
+                                <option value=""><?php esc_html_e( 'Choose an action', 'wp-ai-assistant' ); ?></option>
+                                <option value="view"><?php esc_html_e( 'View conversation', 'wp-ai-assistant' ); ?></option>
+                                <option value="delete"><?php esc_html_e( 'Delete permanently', 'wp-ai-assistant' ); ?></option>
+                        </select>
+                        <button type="button" id="wpai-bulk-action-apply" class="wpai-bulk-action-apply"><?php esc_html_e( 'Apply', 'wp-ai-assistant' ); ?></button>
+                </div>
 
-						<?php if ( ! empty( $thread['last_message']['assistant_message'] ) ) : ?>
-							<div class="wpai-preview-assistant">
-								<span class="preview-label"><?php esc_html_e( 'Assistant:', 'wp-ai-assistant' ); ?></span> <?php echo esc_html( wp_trim_words( $thread['last_message']['assistant_message'], 20 ) ); ?>
-							</div>
-						<?php endif; ?>
-					</div>
+                <p class="wpai-history-empty" aria-live="polite"><?php esc_html_e( 'No conversations match the selected filters.', 'wp-ai-assistant' ); ?></p>
 
-					<div class="wpai-thread-actions">
-						<button class="wpai-view-thread">
-							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
-								<circle cx="12" cy="12" r="3"></circle>
-							</svg>
-							<?php esc_html_e( 'View conversation', 'wp-ai-assistant' ); ?>
-						</button>
-						<button class="wpai-continue-chat"
-							data-thread-id="<?php echo esc_attr( $thread['thread_id'] ); ?>"
-							<?php if ( ! empty( $redirect ) ) : ?>
-							data-redirect-url="<?php echo esc_url( $redirect ); ?>"
-							<?php endif; ?>>
-							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<polyline points="9 18 15 12 9 6"></polyline>
-							</svg>
-							<?php esc_html_e( 'Continue chat', 'wp-ai-assistant' ); ?>
-						</button>
-					</div>
+                <div class="wpai-history-threads">
+                        <?php foreach ( $threads as $thread ) :
+                                $messages    = isset( $thread['messages'] ) && is_array( $thread['messages'] ) ? $thread['messages'] : array();
+                                $last_message = ! empty( $messages ) ? end( $messages ) : array();
+                                $last_role   = isset( $last_message['role'] ) ? $last_message['role'] : '';
+                                $status      = 'unknown';
 
-					<div class="wpai-thread-messages">
-						<?php foreach ( $thread['messages'] as $message ) : ?>
-							<div class="wpai-message wpai-message-<?php echo esc_attr( $message['role'] ); ?>">
-								<div class="wpai-message-header">
-									<strong class="message-role"><?php echo esc_html( $message['role'] === 'user' ? __( 'You', 'wp-ai-assistant' ) : __( 'Assistant', 'wp-ai-assistant' ) ); ?></strong>
-									<?php if ( ! empty( $message['timestamp'] ) ) : ?>
-										<span class="wpai-message-time"><?php echo date( 'd/m/Y H:i', $message['timestamp'] ); ?></span>
-									<?php endif; ?>
-								</div>
-								<div class="wpai-message-content">
-									<?php echo $parsedown->text( $message['content'] ); ?>
-								</div>
-							</div>
-						<?php endforeach; ?>
-					</div>
-				</div>
-			<?php endforeach; ?>
-		</div>
-	<?php endif; ?>
+                                if ( 'assistant' === $last_role ) {
+                                        $status = 'answered';
+                                } elseif ( 'user' === $last_role ) {
+                                        $status = 'pending';
+                                }
+
+                                if ( ! empty( $messages ) ) {
+                                        reset( $messages );
+                                }
+
+                                $post_id         = isset( $thread['post_id'] ) ? (int) $thread['post_id'] : 0;
+                                $summary         = isset( $thread['summary'] ) ? $thread['summary'] : '';
+                                $selection_label = $summary ? $summary : ( $thread['title'] ?? '' );
+                        ?>
+                                <div class="wpai-thread" data-thread-id="<?php echo esc_attr( $thread['thread_id'] ); ?>" data-post-id="<?php echo esc_attr( $post_id ); ?>" data-status="<?php echo esc_attr( $status ); ?>">
+                                        <div class="wpai-thread-header">
+                                                <div class="wpai-thread-select">
+                                                        <input type="checkbox" class="wpai-thread-checkbox" value="<?php echo esc_attr( $post_id ); ?>" data-thread-id="<?php echo esc_attr( $thread['thread_id'] ); ?>" aria-label="<?php printf( esc_attr__( 'Select conversation "%s"', 'wp-ai-assistant' ), esc_attr( wp_strip_all_tags( $selection_label ) ) ); ?>" />
+                                                </div>
+                                                <div class="wpai-thread-header-content">
+                                                        <h3><?php echo esc_html( $summary ); ?></h3>
+                                                        <span class="wpai-thread-date"><?php echo esc_html( $thread['date'] ); ?></span>
+                                                </div>
+                                        </div>
+
+                                        <div class="wpai-thread-preview">
+                                                <?php if ( ! empty( $thread['last_message']['user_message'] ) ) : ?>
+                                                        <div class="wpai-preview-user">
+                                                                <span class="preview-label"><?php esc_html_e( 'You:', 'wp-ai-assistant' ); ?></span> <?php echo esc_html( wp_trim_words( $thread['last_message']['user_message'], 15 ) ); ?>
+                                                        </div>
+                                                <?php endif; ?>
+
+                                                <?php if ( ! empty( $thread['last_message']['assistant_message'] ) ) : ?>
+                                                        <div class="wpai-preview-assistant">
+                                                                <span class="preview-label"><?php esc_html_e( 'Assistant:', 'wp-ai-assistant' ); ?></span> <?php echo esc_html( wp_trim_words( $thread['last_message']['assistant_message'], 20 ) ); ?>
+                                                        </div>
+                                                <?php endif; ?>
+                                        </div>
+
+                                        <div class="wpai-thread-actions">
+                                                <button class="wpai-view-thread">
+                                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                                                                <circle cx="12" cy="12" r="3"></circle>
+                                                        </svg>
+                                                        <?php esc_html_e( 'View conversation', 'wp-ai-assistant' ); ?>
+                                                </button>
+                                                <button class="wpai-continue-chat"
+                                                        data-thread-id="<?php echo esc_attr( $thread['thread_id'] ); ?>"
+                                                        <?php if ( ! empty( $redirect ) ) : ?>
+                                                        data-redirect-url="<?php echo esc_url( $redirect ); ?>"
+                                                        <?php endif; ?>>
+                                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                                <polyline points="9 18 15 12 9 6"></polyline>
+                                                        </svg>
+                                                        <?php esc_html_e( 'Continue chat', 'wp-ai-assistant' ); ?>
+                                                </button>
+                                        </div>
+
+                                        <div class="wpai-thread-messages">
+                                                <?php foreach ( $thread['messages'] as $message ) : ?>
+                                                        <div class="wpai-message wpai-message-<?php echo esc_attr( $message['role'] ); ?>">
+                                                                <div class="wpai-message-header">
+                                                                        <strong class="message-role"><?php echo esc_html( $message['role'] === 'user' ? __( 'You', 'wp-ai-assistant' ) : __( 'Assistant', 'wp-ai-assistant' ) ); ?></strong>
+                                                                        <?php if ( ! empty( $message['timestamp'] ) ) : ?>
+                                                                                <span class="wpai-message-time"><?php echo date( 'd/m/Y H:i', $message['timestamp'] ); ?></span>
+                                                                        <?php endif; ?>
+                                                                </div>
+                                                                <div class="wpai-message-content">
+                                                                        <?php echo $parsedown->text( $message['content'] ); ?>
+                                                                </div>
+                                                        </div>
+                                                <?php endforeach; ?>
+                                        </div>
+                                </div>
+                        <?php endforeach; ?>
+                </div>
+<?php endif; ?>
 </div>

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -88,10 +88,12 @@ class Plugin {
 		Assistant::set_thread_repository( $thread_repository );
 
 		// Hooks AJAX.
-		add_action( 'wp_ajax_wp_ai_assistant_request', array( $this, 'handle_chatbot_request' ) );
-		add_action( 'wp_ajax_nopriv_wp_ai_assistant_request', array( $this, 'handle_chatbot_request' ) );
-		add_action( 'wp_ajax_wp_ai_assistant_admin_test', array( $this, 'handle_admin_test_request' ) );
-		add_action( 'wp_ajax_wp_ai_assistant_generate_summary', array( $this, 'handle_generate_summary_request' ) );
+                add_action( 'wp_ajax_wp_ai_assistant_request', array( $this, 'handle_chatbot_request' ) );
+                add_action( 'wp_ajax_nopriv_wp_ai_assistant_request', array( $this, 'handle_chatbot_request' ) );
+                add_action( 'wp_ajax_wp_ai_assistant_admin_test', array( $this, 'handle_admin_test_request' ) );
+                add_action( 'wp_ajax_wp_ai_assistant_generate_summary', array( $this, 'handle_generate_summary_request' ) );
+                add_action( 'wp_ajax_wp_ai_assistant_delete_threads', array( $this, 'handle_delete_threads' ) );
+                add_action( 'wp_ajax_nopriv_wp_ai_assistant_delete_threads', array( $this, 'handle_delete_threads' ) );
 	}
 
 	/**
@@ -279,5 +281,106 @@ class Plugin {
 
                 wp_send_json_success( array( 'summary' => $summary ) );
                 wp_die();
+        }
+
+        /**
+         * Handle AJAX requests to delete conversation threads.
+         */
+        public function handle_delete_threads() {
+                $nonce = isset( $_POST['_ajax_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_ajax_nonce'] ) ) : '';
+
+                if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, 'wp_ai_assistant_history_nonce' ) ) {
+                        wp_send_json_error(
+                                array( 'message' => __( 'Security check failed.', 'wp-ai-assistant' ) ),
+                                403
+                        );
+                }
+
+                $raw_ids    = isset( $_POST['thread_ids'] ) ? wp_unslash( $_POST['thread_ids'] ) : '[]';
+                $thread_ids = json_decode( $raw_ids, true );
+
+                if ( ! is_array( $thread_ids ) ) {
+                        wp_send_json_error(
+                                array( 'message' => __( 'Invalid conversation data received.', 'wp-ai-assistant' ) ),
+                                400
+                        );
+                }
+
+                $thread_ids = array_filter(
+                        array_map( 'absint', $thread_ids ),
+                        static function ( $id ) {
+                                return $id > 0;
+                        }
+                );
+
+                if ( empty( $thread_ids ) ) {
+                        wp_send_json_error(
+                                array( 'message' => __( 'Select at least one conversation to delete.', 'wp-ai-assistant' ) ),
+                                400
+                        );
+                }
+
+                $session_id = '';
+
+                try {
+                        $session_id = Session::get_session_id();
+                } catch ( \Throwable $e ) {
+                        $session_id = '';
+                }
+
+                $current_user_id = get_current_user_id();
+                $deleted         = array();
+                $failed          = array();
+
+                foreach ( $thread_ids as $post_id ) {
+                        $post = get_post( $post_id );
+
+                        if ( ! $post || 'ai_chat_thread' !== $post->post_type ) {
+                                $failed[] = $post_id;
+                                continue;
+                        }
+
+                        $allowed = false;
+
+                        if ( $current_user_id > 0 && ( (int) $post->post_author === $current_user_id || current_user_can( 'delete_post', $post_id ) ) ) {
+                                $allowed = true;
+                        } else {
+                                $stored_session = get_post_meta( $post_id, 'session_id', true );
+                                if ( $session_id && ! empty( $stored_session ) && $stored_session === $session_id ) {
+                                        $allowed = true;
+                                }
+                        }
+
+                        if ( ! $allowed ) {
+                                $failed[] = $post_id;
+                                continue;
+                        }
+
+                        $result = wp_delete_post( $post_id, true );
+
+                        if ( false === $result ) {
+                                $failed[] = $post_id;
+                                continue;
+                        }
+
+                        $deleted[] = $post_id;
+                }
+
+                if ( empty( $deleted ) ) {
+                        wp_send_json_error(
+                                array(
+                                        'message' => __( 'No conversations could be deleted.', 'wp-ai-assistant' ),
+                                        'failed'  => $failed,
+                                ),
+                                403
+                        );
+                }
+
+                wp_send_json_success(
+                        array(
+                                'deleted' => $deleted,
+                                'failed'  => $failed,
+                        )
+                );
         }
 }


### PR DESCRIPTION
## Summary
- ensure the conversation history page loads with no filters applied and expose new filter chips plus a sticky bulk action bar when items are selected
- allow viewing or permanently deleting selected conversations via the actions dropdown with a single confirmation prompt, keeping the control visible while scrolling
- localize the new interface strings and add an AJAX handler that validates ownership before force-deleting the chosen threads

## Testing
- npm run build
- php -l src/Plugin.php
- php -l src/Frontend/templates/history-template.php

------
https://chatgpt.com/codex/tasks/task_e_68da8f240fac8321a9955fbb301d71de